### PR TITLE
read access token and client identifier from config

### DIFF
--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/ConnectorHandle.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/ConnectorHandle.java
@@ -21,12 +21,17 @@ import org.apache.drill.common.logical.StoragePluginConfig;
 import org.apache.drill.exec.store.PluginHandle.PluginType;
 import org.apache.drill.shaded.guava.com.google.common.base.Preconditions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Defines a storage connector: a storage plugin config along with the
  * locator which can create a plugin instance given an instance of the
  * config.
  */
 public class ConnectorHandle {
+
+  private static final Logger logger = LoggerFactory.getLogger(ConnectorHandle.class);
 
   private final ConnectorLocator locator;
   private final Class<? extends StoragePluginConfig> configClass;

--- a/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DropboxFileSystem.java
+++ b/exec/java-exec/src/main/java/org/apache/drill/exec/store/dfs/DropboxFileSystem.java
@@ -49,8 +49,6 @@ import java.util.Map;
 
 public class DropboxFileSystem extends FileSystem {
   private static final Logger logger = LoggerFactory.getLogger(DropboxFileSystem.class);
-  // TODO Get this from the config or password vault
-  private static final String ACCESS_TOKEN = "e9aB6wxgt6kAAAAAAAAAAayiv0u56eRpMeioVAiHIunhH2SuJoadXFxMKSjlZVTk";
 
   private static final String ERROR_MSG = "Dropbox is read only.";
   private Path workingDirectory;
@@ -81,7 +79,6 @@ public class DropboxFileSystem extends FileSystem {
     }
     return fsDataInputStream;
   }
-
 
   @Override
   public FSDataOutputStream create(Path f,
@@ -196,8 +193,16 @@ public class DropboxFileSystem extends FileSystem {
       return client;
     }
 
-    DbxRequestConfig config = DbxRequestConfig.newBuilder("datadistillr").build();
-    this.client = new DbxClientV2(config, ACCESS_TOKEN);
+    // read preferred client identifier from config or use "Apache/Drill"
+    String clientIdentifier = this.getConf().get("clientIdentifier", "Apache/Drill");
+    logger.info("Creating dropbox client with client identifier: {}", clientIdentifier);
+    DbxRequestConfig config = DbxRequestConfig.newBuilder(clientIdentifier).build();
+
+    // read access token from config or credentials provider
+    logger.info("Reading dropbox access token from configuration or credentials provider");
+    String accessToken = this.getConf().get("dropboxAccessToken", "");
+
+    this.client = new DbxClientV2(config, accessToken);
     return this.client;
   }
 


### PR DESCRIPTION
# Read Access Token and Client Identifier from Config

## Description

I changed the behavior of the Dropbox FileSystem to use as access token the configuration value `dropboxAccessToken`, which may be provided by a credentialProvider. The Dropbox client will also check for `clientIdentification` in the config, otherwise will identify itself as "Apache/Drill".

## Documentation

You can connect to a Dropbox file system this way:

```json
{
  "type": "file",
  "connection": "dropbox:///",
  "config": {
    "dropboxAccessToken": "ACCESS_TOKEN_HERE"
  },
  "workspaces": {...},
  "formats": {...}
}
```

Your access token must be generated by your Dropbox developer account. Alternatively, you can specifiy your access token using a Credential Provider. Either way, the access token must be made accessible as `dropboxAccessToken`.

## Testing

I used it to acess my own Dropbox account and query CSVs.
