### PR TITLE
Added first cut at attribute support.

### DIFF
--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLReader.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/XMLReader.java
@@ -58,7 +58,7 @@ import java.util.Stack;
 
 public class XMLReader implements Closeable {
   private static final Logger logger = LoggerFactory.getLogger(XMLReader.class);
-  private static final String ATTRIBUTE_MAP_NAME = "attributes";
+  public static final String ATTRIBUTE_MAP_NAME = "attributes";
 
   private final Stack<String> fieldNameStack;
   private final Stack<TupleWriter> rowWriterStack;

--- a/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/xsd/DrillXSDSchemaVisitor.java
+++ b/contrib/format-xml/src/main/java/org/apache/drill/exec/store/xml/xsd/DrillXSDSchemaVisitor.java
@@ -117,7 +117,9 @@ public class DrillXSDSchemaVisitor implements XmlSchemaVisitor {
 
   @Override
   public void onVisitAttribute(XmlSchemaElement xmlSchemaElement, XmlSchemaAttrInfo xmlSchemaAttrInfo) {
-    // no op
+    String fieldName = xmlSchemaAttrInfo.getAttribute().getName();
+    MinorType dataType = DrillXSDSchemaUtils.getDrillDataType(xmlSchemaAttrInfo.getType().getBaseType().name());
+    currentMapBuilder.addNullable(fieldName, dataType);
   }
 
   @Override

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/xsd/TestXSDSchema.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/xsd/TestXSDSchema.java
@@ -38,14 +38,16 @@ public class TestXSDSchema {
 
     TupleMetadata expectedSchema  = new SchemaBuilder()
         .addMap("shiporder")
-          .addNullable("orderid", MinorType.VARCHAR)
+          .addMap("attributes")
+            .addNullable("orderid", MinorType.VARCHAR)
+          .resumeMap()
           .addNullable("orderperson", MinorType.VARCHAR)
           .addMap("shipto")
             .addNullable("name", MinorType.VARCHAR)
             .addNullable("address", MinorType.VARCHAR)
             .addNullable("city", MinorType.VARCHAR)
             .addNullable("country", MinorType.VARCHAR)
-          .resumeMap()
+        .resumeMap()
           .addMapArray("item")
             .addNullable("title", MinorType.VARCHAR)
             .addNullable("note", MinorType.VARCHAR)
@@ -66,11 +68,20 @@ public class TestXSDSchema {
     SchemaBuilder sb1 = new SchemaBuilder();
     MapBuilder sb2 = sb1
         .addNullable("comment", MinorType.VARCHAR) // global comment element
+        .addMap("infoType")
+          .addMap("attributes")
+            .addNullable("kind", MinorType.VARCHAR)
+          .resumeMap()
+        .resumeSchema()
         .addMap("purchaseOrder") // global purchaseOrder element
-          .addNullable("orderDate", MinorType.DATE) // an attribute
-          .addNullable("confirmDate", MinorType.DATE) // an attribute
+          .addMap("attributes")
+            .addNullable("orderDate", MinorType.DATE) // an attribute
+            .addNullable("confirmDate", MinorType.DATE) // an attribute
+          .resumeMap()
           .addMap("shipTo")
-            .addNullable("country", MinorType.VARCHAR) // an attribute
+            .addMap("attributes")
+              .addNullable("country", MinorType.VARCHAR) // an attribute
+            .resumeMap()
             .addNullable("name", MinorType.VARCHAR)
             .addNullable("street", MinorType.VARCHAR)
             .addNullable("city", MinorType.VARCHAR)
@@ -79,7 +90,9 @@ public class TestXSDSchema {
           .resumeMap(); // end shipTo
     MapBuilder sb3 = sb2
           .addMap("billTo")
-            .addNullable("country", MinorType.VARCHAR) // an attribute
+            .addMap("attributes")
+              .addNullable("country", MinorType.VARCHAR) // an attribute
+            .resumeMap()
             .addNullable("name", MinorType.VARCHAR)
             .addNullable("street", MinorType.VARCHAR)
              .addNullable("city", MinorType.VARCHAR)
@@ -90,7 +103,9 @@ public class TestXSDSchema {
           .addNullable("comment", MinorType.VARCHAR)
           .addMap("items")
             .addMapArray("item")
-              .addNullable("partNum", MinorType.VARCHAR) // an attribute
+              .addMap("attributes")
+                .addNullable("partNum", MinorType.VARCHAR) // an attribute
+             .resumeMap()
               .addNullable("productName", MinorType.VARCHAR)
               .addNullable("quantity", MinorType.VARDECIMAL)
               .addNullable("USPrice", MinorType.VARDECIMAL)

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/xsd/TestXSDSchema.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/xsd/TestXSDSchema.java
@@ -38,6 +38,7 @@ public class TestXSDSchema {
 
     TupleMetadata expectedSchema  = new SchemaBuilder()
         .addMap("shiporder")
+          .addNullable("orderid", MinorType.VARCHAR)
           .addNullable("orderperson", MinorType.VARCHAR)
           .addMap("shipto")
             .addNullable("name", MinorType.VARCHAR)

--- a/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/xsd/TestXSDSchema.java
+++ b/contrib/format-xml/src/test/java/org/apache/drill/exec/store/xml/xsd/TestXSDSchema.java
@@ -66,7 +66,10 @@ public class TestXSDSchema {
     MapBuilder sb2 = sb1
         .addNullable("comment", MinorType.VARCHAR) // global comment element
         .addMap("purchaseOrder") // global purchaseOrder element
+          .addNullable("orderDate", MinorType.DATE) // an attribute
+          .addNullable("confirmDate", MinorType.DATE) // an attribute
           .addMap("shipTo")
+            .addNullable("country", MinorType.VARCHAR) // an attribute
             .addNullable("name", MinorType.VARCHAR)
             .addNullable("street", MinorType.VARCHAR)
             .addNullable("city", MinorType.VARCHAR)
@@ -75,6 +78,7 @@ public class TestXSDSchema {
           .resumeMap(); // end shipTo
     MapBuilder sb3 = sb2
           .addMap("billTo")
+            .addNullable("country", MinorType.VARCHAR) // an attribute
             .addNullable("name", MinorType.VARCHAR)
             .addNullable("street", MinorType.VARCHAR)
              .addNullable("city", MinorType.VARCHAR)
@@ -85,15 +89,13 @@ public class TestXSDSchema {
           .addNullable("comment", MinorType.VARCHAR)
           .addMap("items")
             .addMapArray("item")
+              .addNullable("partNum", MinorType.VARCHAR) // an attribute
               .addNullable("productName", MinorType.VARCHAR)
               .addNullable("quantity", MinorType.VARDECIMAL)
               .addNullable("USPrice", MinorType.VARDECIMAL)
               .addNullable("comment", MinorType.VARCHAR)
               .addNullable("shipDate", MinorType.DATE)
-//              .addNullable("partNum", MinorType.VARCHAR) // attributes are not being added yet
             .resumeMap() // end item
-//            .addNullable("orderDate", MinorType.DATE) // attributes are not being added yet
-//            .add("confirmDate", MinorType.DATE) // attributes are not being added yet
           .resumeMap(); // end items
 
     TupleMetadata expectedSchema = sb4.resumeSchema().build();

--- a/contrib/format-xml/src/test/resources/xsd/complex.xsd
+++ b/contrib/format-xml/src/test/resources/xsd/complex.xsd
@@ -2,7 +2,23 @@
             xmlns:tns="http://tempuri.org/PurchaseOrderSchema.xsd"
             targetNamespace="http://tempuri.org/PurchaseOrderSchema.xsd"
             elementFormDefault="qualified">
+
+  <!-- example of global simple type element -->
     <xsd:element name='comment' type='xsd:string'/>
+
+  <!-- example of complex type with ONLY attributes -->
+    <xsd:element name='infoType'>
+      <xsd:complexType>
+        <xsd:attribute name="kind">
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:token">
+              <xsd:enumeration value="byte"/>
+              <xsd:enumeration value="bit"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:attribute>
+      </xsd:complexType>
+    </xsd:element>
 
     <xsd:element name='purchaseOrder' type='tns:PurchaseOrderType'/>
 
@@ -10,7 +26,6 @@
      an element declaration -->
 
     <xsd:attribute name="aGlobalAttribute" type="xsd:string"/>
-
 
     <xsd:complexType name='USAddress'>
         <xsd:annotation>

--- a/contrib/format-xml/src/test/resources/xsd/complex.xsd
+++ b/contrib/format-xml/src/test/resources/xsd/complex.xsd
@@ -6,6 +6,12 @@
 
     <xsd:element name='purchaseOrder' type='tns:PurchaseOrderType'/>
 
+    <!-- global attribute and attributeGroups are ignored unless referenced from within
+     an element declaration -->
+
+    <xsd:attribute name="aGlobalAttribute" type="xsd:string"/>
+
+
     <xsd:complexType name='USAddress'>
         <xsd:annotation>
             <xsd:documentation>
@@ -59,7 +65,11 @@
             <xsd:element ref='tns:comment' minOccurs='0'/>
             <xsd:element name='items'  type='tns:Items'/>
         </xsd:sequence>
-        <xsd:attribute name='orderDate' type='xsd:date'/>
-        <xsd:attribute name='confirmDate' type='xsd:date' use='required'/>
+        <xsd:attributeGroup ref="tns:dates"/>
     </xsd:complexType>
+
+  <xsd:attributeGroup name="dates">
+    <xsd:attribute name='orderDate' type='xsd:date'/>
+    <xsd:attribute name='confirmDate' type='xsd:date' use='required'/>
+  </xsd:attributeGroup>
 </xsd:schema>


### PR DESCRIPTION
Test enhanced to use attributes and global attributeGroup definition and reference as well as local attribute declarations.

Does not detect, nor handle,  the fact that an attribute is allowed to have the exact same name as an element in XML Schema.

Currently does not distinguish optional/required attributes (they're all addNullable), and does not implement XSD default/fixed.

Note that attribute definitions in XSD come last in the element definition lexically; however, they come out first in Drill field order. This is consistent with the way XML text looks where the element tag carries attributes first, in the opening tag, then child elements follow after the opening tag.
