### PR TITLE
Fix dashboards created in a project being orphaned and unopenable

### DIFF
--- a/exec/java-exec/src/main/resources/webapp/src/App.tsx
+++ b/exec/java-exec/src/main/resources/webapp/src/App.tsx
@@ -114,7 +114,7 @@ function App() {
               <Route path="/visualizations" element={<VisualizationsPage />} />
               <Route path="/visualizations/:vizId" element={<VisualizationDetailPage />} />
               <Route path="/dashboards" element={<DashboardsPage />} />
-              <Route path="/dashboards/:id" element={<DashboardViewPage />} />
+              <Route path="/dashboards/:dashboardId" element={<DashboardViewPage />} />
               <Route path="/metrics" element={<MetricsPage />} />
               <Route path="/options" element={<OptionsPage />} />
               <Route path="/logs" element={<LogsPage />} />

--- a/exec/java-exec/src/main/resources/webapp/src/hooks/useProspector.test.tsx
+++ b/exec/java-exec/src/main/resources/webapp/src/hooks/useProspector.test.tsx
@@ -20,13 +20,16 @@ import { renderHook, waitFor } from '@testing-library/react';
 
 import { useProspector } from './useProspector';
 import { createVisualization } from '../api/visualizations';
-import { addVisualization, getProject } from '../api/projects';
+import { createDashboard } from '../api/dashboards';
+import { addVisualization, addDashboard, getProject } from '../api/projects';
 import { executeQuery } from '../api/queries';
 import { getAiStatus, streamChat } from '../api/ai';
 import type { ChatContext, ToolCall } from '../types/ai';
 
 vi.mock('../api/visualizations', () => ({ createVisualization: vi.fn() }));
-vi.mock('../api/projects', () => ({ addVisualization: vi.fn(), getProject: vi.fn() }));
+vi.mock('../api/projects', () => ({
+  addVisualization: vi.fn(), addDashboard: vi.fn(), getProject: vi.fn(),
+}));
 vi.mock('../api/ai', () => ({ streamChat: vi.fn(), getAiStatus: vi.fn() }));
 vi.mock('../api/queries', () => ({ executeQuery: vi.fn() }));
 vi.mock('../api/metadata', () => ({
@@ -116,6 +119,37 @@ describe('create_visualization tool', () => {
     expect(out.error).toContain('boom');
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+});
+
+describe('create_dashboard tool', () => {
+  const dashCall = (): ToolCall => ({
+    id: 'call-3',
+    name: 'create_dashboard',
+    arguments: JSON.stringify({ name: 'Sales Overview', panels: [] }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createDashboard).mockResolvedValue({ id: 'dash-1', name: 'Sales Overview' } as never);
+    vi.mocked(addDashboard).mockResolvedValue({} as never);
+  });
+
+  it('adds the dashboard to the active project', async () => {
+    const { result } = renderHook(() => useProspector());
+    const out = JSON.parse(await result.current.executeToolCall(dashCall(), ctx('proj-42')));
+
+    expect(addDashboard).toHaveBeenCalledWith('proj-42', 'dash-1');
+    expect(out.addedToProject).toBe(true);
+  });
+
+  it('creates the dashboard without a project when there is no active project', async () => {
+    const { result } = renderHook(() => useProspector());
+    const out = JSON.parse(await result.current.executeToolCall(dashCall(), ctx()));
+
+    expect(createDashboard).toHaveBeenCalledOnce();
+    expect(addDashboard).not.toHaveBeenCalled();
+    expect(out.addedToProject).toBe(false);
   });
 });
 

--- a/exec/java-exec/src/main/resources/webapp/src/hooks/useProspector.ts
+++ b/exec/java-exec/src/main/resources/webapp/src/hooks/useProspector.ts
@@ -21,7 +21,7 @@ import { useSendDataToAi } from './useSendDataToAi';
 import { executeQuery } from '../api/queries';
 import { getSchemas, getTables, getColumns, getFunctions } from '../api/metadata';
 import { createVisualization } from '../api/visualizations';
-import { addVisualization, getProject } from '../api/projects';
+import { addVisualization, addDashboard, getProject } from '../api/projects';
 import { createDashboard } from '../api/dashboards';
 import { createSavedQuery } from '../api/savedQueries';
 import type {
@@ -353,9 +353,25 @@ export function useProspector(
             description: args.description,
             panels: args.panels,
           });
+
+          // Same orphaning problem as create_visualization above.
+          let addedToProject = false;
+          let projectError: string | undefined;
+          if (context?.projectId) {
+            try {
+              await addDashboard(context.projectId, dashboard.id);
+              addedToProject = true;
+            } catch (err) {
+              projectError = err instanceof Error ? err.message : 'unknown error';
+              console.error('Failed to add dashboard to project', err);
+            }
+          }
+
           return JSON.stringify({
             id: dashboard.id,
             name: dashboard.name,
+            addedToProject,
+            ...(projectError ? { projectError } : {}),
             message: `Dashboard "${dashboard.name}" created successfully.`,
             viewPath: '/dashboards',
           });

--- a/exec/java-exec/src/main/resources/webapp/src/pages/DashboardsPage.tsx
+++ b/exec/java-exec/src/main/resources/webapp/src/pages/DashboardsPage.tsx
@@ -62,7 +62,8 @@ import {
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import { useUndoableDelete } from '../hooks/useUndoableDelete';
 import { usePageChrome } from '../contexts/AppChromeContext';
-import type { Dashboard, DashboardPanel, DashboardPanelType } from '../types';
+import { addDashboard } from '../api/projects';
+import type { Dashboard, DashboardCreate, DashboardPanel, DashboardPanelType } from '../types';
 import AddToProjectModal from '../components/common/AddToProjectModal';
 import BulkAddToProjectModal from '../components/common/BulkAddToProjectModal';
 
@@ -193,10 +194,19 @@ export default function DashboardsPage({ filterIds, projectId, projectName, proj
   });
 
   const createMutation = useMutation({
-    mutationFn: createDashboard,
+    // Created inside a project? Link it, or the dashboard is orphaned and never
+    // shows up on the project's dashboards page (which filters on dashboardIds).
+    mutationFn: async (data: DashboardCreate) => {
+      const created = await createDashboard(data);
+      if (projectId) {
+        await addDashboard(projectId, created.id);
+      }
+      return created;
+    },
     onSuccess: (newDashboard) => {
       message.success('Dashboard created');
       queryClient.invalidateQueries({ queryKey: ['dashboards'] });
+      queryClient.invalidateQueries({ queryKey: ['project', projectId] });
       setCreateModalOpen(false);
       createForm.resetFields();
       const dashboardPath = projectId


### PR DESCRIPTION
Two independent bugs in the dashboard creation flow, both reported together: create a dashboard inside a project, save it, and it is missing from the project's dashboards page; find it on the global list and clicking it says "Dashboard not found".

## Dashboard is not linked to the project

`DashboardsPage`'s create mutation called `createDashboard` and stopped. The project dashboards page filters on `project.dashboardIds` (`ProjectDashboardsPage.tsx:38`), so a dashboard created in project context was orphaned and never showed up there. It now calls `addDashboard(projectId, id)` on create and invalidates the project query — the same thing `ExportImportModal` already did on its import path.

## "Dashboard not found" from the global list

`App.tsx` declared the global route as `/dashboards/:id`, but `DashboardViewPage` reads `useParams<{ dashboardId }>()`. On that route `dashboardId` was `undefined`, so the query stayed disabled, `dashboard` was never populated, and the `!dashboard` branch rendered the not-found alert. The route parameter is renamed to `:dashboardId`, matching both the component and the project-scoped route.

## Prospector

`create_dashboard` in `useProspector` had the same orphaning bug — it had diverged from the `create_visualization` tool directly above it, which already links to the active project and reports partial failures. Brought back in line, with tests.

## Testing

- `useProspector.test.tsx` — 19 passing, including two new cases asserting the dashboard is linked when a project is active and not linked when there isn't one
- `tsc --noEmit` clean
- Unrelated pre-existing failures in `useRecentItems.test.ts` and `NotebookPanel.test.tsx` (localStorage undefined) are unchanged; confirmed failing before these changes
- Not yet exercised in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)